### PR TITLE
_ no longer gets set as a window variable

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -11,7 +11,7 @@ module.exports = (file) ->
             buffer += chunk.toString()
     ,
         () ->
-            compiled = "_ = require('underscore');\n";
+            compiled = "var _ = require('underscore');\n";
             jst = _.template(buffer.toString()).source;
             compiled += "module.exports = " + jst + ";\n";
             @queue(compiled)

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function(file) {
     return buffer += chunk.toString();
   }, function() {
     var compiled, jst;
-    compiled = "_ = require('underscore');\n";
+    compiled = "var _ = require('underscore');\n";
     jst = _.template(buffer.toString()).source;
     compiled += "module.exports = " + jst + ";\n";
     this.queue(compiled);


### PR DESCRIPTION
I run an application that loads in Lodash noConflicted. Using node-underscorify (which is great btw) it ends up setting `window._` during compilation. Adding a `var` removes this issue.
